### PR TITLE
Always return cloned object from dissocPath

### DIFF
--- a/dissocPath.ts
+++ b/dissocPath.ts
@@ -28,9 +28,13 @@ function _remove(index: number, arr: any[]) {
 }
 
 function _dissocPath(path: Path, obj: ObjRec): ObjRec {
+  // create shallow clone of obj
+  let result: ObjRec
+  if (isArray(obj)) result = [...obj]
+  else result = { ...obj }
   const p = getPath(path)
   const prop = p[0]
-  if (p.length === 0) return obj
+  if (p.length === 0) return result
   if (p.length === 1) {
     if (isInteger(prop) && isArray(obj)) return _remove(prop, obj)
     return dissoc(prop, obj)

--- a/specs/dissocPath.test.ts
+++ b/specs/dissocPath.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from './_describe.ts'
 import { dissocPath, _ } from '../mod.ts'
-import { eq, strictEq } from './utils/utils.ts'
+import { eq, strictEq, strictNotEq } from './utils/utils.ts'
 
 describe('dissocPath', () => {
   it('should make a shallow clone of an object, omitting only what is necessary for the path', () => {
@@ -75,5 +75,11 @@ describe('dissocPath', () => {
     eq(dissocPath(a)(b), expected)
     eq(dissocPath(a, _)(b), expected)
     eq(dissocPath(_, b)(a), expected)
+  })
+  it('should make a shallow clone of an object when the path is empty', () => {
+    const obj1 = { a: 1, b: 2 }
+    const result = dissocPath([], obj1)
+    eq(result, obj1)
+    strictNotEq(result, obj1)
   })
 })


### PR DESCRIPTION
Ensure that a shallow clone of the passed object is returned from `dissocPath` when path is empty.

Resolves #54 