### PR TITLE
57 refine types flip

### DIFF
--- a/.github/workflows/tests-examples.yml
+++ b/.github/workflows/tests-examples.yml
@@ -17,7 +17,7 @@ jobs:
           deno-version: v1.x
 
       - name: Run tests
-        run: deno test
+        run: deno test --doc
 
   examples:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Function usage and documentation can be found [here](https://fae.jozty.io/)
 
 ### Running tests
 
-```typescript
+```shell
 deno test
 # for coverage tests
 deno test --coverage --unstable
@@ -49,9 +49,9 @@ add20(125)                                          // 145
 
 // Expression - (2*5+5-10)/2
 const double = Fae.multiply(2)
-const half = Fae.divide(_, 2)
+const half = Fae.divide(Fae._, 2)
 const add5 = Fae.add(5)
-const subtract10 = Fae.subtract(_, 10)
+const subtract10 = Fae.subtract(Fae._, 10)
 
 half(subtract10(add5(double(15))))                  // 12.5
 Fae.compose(half, subtract10, add5, double)(15)     // 12.5

--- a/flip.ts
+++ b/flip.ts
@@ -6,20 +6,22 @@ import curryN from './utils/curry_n.ts'
 
 /**
  * Returns a new function much like the supplied one, except that the first two
- * arguments' order is reversed.
+ * arguments' order is reversed. The returned function is automatically curried.
+ * But the types are not preserved as of now. For that matter, you can use `Curry1`,
+ * `Curry2`, `Curry3`.
  *
  *
  *      const mergeThree = (a, b, c) => [].concat(a, b, c)
  *      mergeThree(1, 2, 3); // [1, 2, 3]
  *      Fae.flip(mergeThree)(1, 2, 3); // [2, 1, 3]
  */
-export function flip(fn: Func) {
+export function flip<T, A extends unknown[], R>(fn: (a: T, b: T, ...rest: A) => R) {
   return curryN(getFunctionLength(fn), function (
     this: any,
-    a: any,
-    b: any,
-    ...rest: any[]
+    b: T,
+    a: T,
+    ...rest: A
   ) {
-    return fn.apply(this, [b, a, ...rest])
-  } as typeof fn)
+    return fn.apply(this, [a, b, ...rest])
+  })
 }

--- a/flip.ts
+++ b/flip.ts
@@ -7,13 +7,27 @@ import curryN from './utils/curry_n.ts'
 /**
  * Returns a new function much like the supplied one, except that the first two
  * arguments' order is reversed. The returned function is automatically curried.
- * But the types are not preserved as of now. For that matter, you can use `Curry1`,
- * `Curry2`, `Curry3`.
+ * But the types are not preserved as of now due to TS limitations. The returned function
+ * will have all unknown in its parameters list and return type. To make it work properly,
+ * you need to use type assertion using `Curry2` or `Curry3`.
  *
- *
- *      const mergeThree = (a, b, c) => [].concat(a, b, c)
- *      mergeThree(1, 2, 3); // [1, 2, 3]
- *      Fae.flip(mergeThree)(1, 2, 3); // [2, 1, 3]
+ * ```ts
+ * import { flip } from './flip.ts'
+ * import { Curry3 } from './utils/types.ts'
+ * 
+ * const mergeThree = (a: number, b: number, c: number) => [a].concat(b, c)
+ * 
+ * mergeThree(1, 2, 3); // [1, 2, 3]
+ * 
+ * const flipped = flip(mergeThree)
+ * 
+ * // @ts-expect-error: append should have been type-asserted
+ * flipped(1, 2)(3); // [2, 1, 3]
+ * 
+ * const flippedWithTypes = flipped as Curry3<number, number, number, number[]>
+ * 
+ * flippedWithTypes(1, 2)(3); // [2, 1, 3]
+ * ```
  */
 export function flip<T, A extends unknown[], R>(fn: (a: T, b: T, ...rest: A) => R) {
   return curryN(getFunctionLength(fn), function (
@@ -23,5 +37,5 @@ export function flip<T, A extends unknown[], R>(fn: (a: T, b: T, ...rest: A) => 
     ...rest: A
   ) {
     return fn.apply(this, [a, b, ...rest])
-  })
+  }) as Func<unknown[], unknown, unknown>
 }

--- a/specs/equals.test.ts
+++ b/specs/equals.test.ts
@@ -61,7 +61,7 @@ describe('equals', () => {
 
   it('should return the curried version', () => {
     eq(equals(_, '')(''), true)
-    eq(equals('', _)('x'), false)
+    eq(equals('')('x'), false)
     eq(equals('x')(''), false)
   })
 

--- a/specs/flip.test.ts
+++ b/specs/flip.test.ts
@@ -2,19 +2,20 @@ import { describe, it } from './_describe.ts'
 import { flip, _ } from '../mod.ts'
 import { eq } from './utils/utils.ts'
 import { getFunctionLength } from '../utils/get.ts'
+import { Curry3, Curry2 } from '../utils/types.ts'
 
 describe('flip', () => {
-  const f = (a: string, b: string, c: string) => a + ' ' + b + ' ' + c
+  const f = (a: string, b: string, c: number) => a + ' ' + b + ' ' + c
   const i = (a: number, b: number, c: number) => a + b * c
   it('should return a function which inverts the first two arguments to the supplied function', () => {
-    const g = flip(f)
-    eq(f('a', 'b', 'c'), 'a b c')
-    eq(g('a', 'b', 'c'), 'b a c')
-    eq(g('a', '@', 'A'), '@ a A')
+    const g: Curry3<string, string, number, string> = flip(f)
+    eq(f('a', 'b', 3), 'a b 3')
+    eq(g('a', 'b', -3), 'b a -3')
+    eq(g('a', '@', Infinity), '@ a Infinity')
   })
 
   it('should return a function which inverts the first two arguments to the supplied function', () => {
-    const h = flip(i)
+    const h: Curry3<number> = flip(i)
     eq(i(2, 3, 4), 14)
     eq(h(2, 3, 4), 11)
     eq(i(2, -3, 4), -10)
@@ -22,17 +23,15 @@ describe('flip', () => {
   })
 
   it('should return a curried function', () => {
-    const g = flip(f)('a')
-    eq(g('b', 'c'), 'b a c')
-    eq(g(_, 'c')('b'), 'b a c')
-    eq(g('b', _)('c'), 'b a c')
-    eq(g(_, _)('b', 'c'), 'b a c')
+    const g: Curry2<string, number, string> = flip(f)('a')
+    eq(g('b', 3), 'b a 3')
+    eq(g(_, 3)('b'), 'b a 3')
+    eq(g('b')(3), 'b a 3')
 
-    const h = flip(i)(2)
+    const h:  Curry2<number> = flip(i)(2)
     eq(h(-4, 5), 6)
-    eq(h(-4, _)(3), 2)
+    eq(h(-4)(3), 2)
     eq(h(_, 3)(-4), 2)
-    eq(h(_, _)(-4, 3), 2)
   })
 
   it('should return a function with the correct arity', () => {

--- a/specs/flip.test.ts
+++ b/specs/flip.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from './_describe.ts'
-import { flip, _ } from '../mod.ts'
+import { flip, _, concat } from '../mod.ts'
 import { eq } from './utils/utils.ts'
 import { getFunctionLength } from '../utils/get.ts'
 import { Curry3, Curry2 } from '../utils/types.ts'
@@ -8,14 +8,14 @@ describe('flip', () => {
   const f = (a: string, b: string, c: number) => a + ' ' + b + ' ' + c
   const i = (a: number, b: number, c: number) => a + b * c
   it('should return a function which inverts the first two arguments to the supplied function', () => {
-    const g: Curry3<string, string, number, string> = flip(f)
+    const g = flip(f) as Curry3<string, string, number, string>
     eq(f('a', 'b', 3), 'a b 3')
     eq(g('a', 'b', -3), 'b a -3')
     eq(g('a', '@', Infinity), '@ a Infinity')
   })
 
   it('should return a function which inverts the first two arguments to the supplied function', () => {
-    const h: Curry3<number> = flip(i)
+    const h = flip(i) as Curry3<number>
     eq(i(2, 3, 4), 14)
     eq(h(2, 3, 4), 11)
     eq(i(2, -3, 4), -10)
@@ -23,15 +23,30 @@ describe('flip', () => {
   })
 
   it('should return a curried function', () => {
-    const g: Curry2<string, number, string> = flip(f)('a')
+    const g = flip(f)('a') as Curry2<string, number, string>
     eq(g('b', 3), 'b a 3')
     eq(g(_, 3)('b'), 'b a 3')
     eq(g('b')(3), 'b a 3')
 
-    const h:  Curry2<number> = flip(i)(2)
+    const h = flip(i)(2) as Curry2<number>
     eq(h(-4, 5), 6)
     eq(h(-4)(3), 2)
     eq(h(_, 3)(-4), 2)
+  })
+
+  it('should enforce using type assertion non the retured function', () => {
+    const mergeThree = (a: number, b: number, c: number) => [a].concat(b, c)
+
+    eq(mergeThree(1, 2, 3), [1, 2, 3])
+
+    const flipped = flip(mergeThree)
+
+    // @ts-expect-error: append should have been type-asserted
+    eq(flipped(1, 2)(3), [2, 1, 3])
+
+    const flippedWithTypes = flipped as Curry3<number, number, number, number[]>
+
+    eq(flippedWithTypes(1, 2)(3), [2, 1, 3])
   })
 
   it('should return a function with the correct arity', () => {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -30,7 +30,7 @@ export interface Curry3<T1, T2 = T1, T3 = T1, R = T1> {
 export type Functor<T> = Iterable<T> | Iterator<T>
 export type FunctorWithArLk<T = unknown> = Functor<T> | ArrayLike<T>
 
-export type Func<A extends any[] = any[], R = any> = ((...args: A) => R) & {
+export type Func<A extends any[] = any[], R = any, This = any> = ((this: This, ...args: A) => R) & {
   [FUNCTION_LENGTH]?: number
 }
 

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -6,30 +6,22 @@ export type PH = PlaceHolder
 
 /** Function type for curried function of arity 1 */
 export interface Curry1<T, R = T> {
-  (a?: PlaceHolder): Curry1<T, R>
   (a: T): R
 }
 
 /** Function type for curried function of arity 2 */
 export interface Curry2<T1, T2 = T1, R = T1> {
-  (t1?: PlaceHolder, t2?: PlaceHolder): Curry2<T1, T2, R>
-  (t1: T1, t2?: PlaceHolder): Curry1<T2, R>
+  (t1: T1): Curry1<T2, R>
   (t1: PlaceHolder, t2: T2): Curry1<T1, R>
   (t1: T1, t2: T2): R
 }
 
 /** Function type for curried function of arity 3 */
 export interface Curry3<T1, T2 = T1, T3 = T1, R = T1> {
-  (t1?: PlaceHolder, t2?: PlaceHolder, t3?: PlaceHolder): Curry3<
-    T1,
-    T2,
-    T3,
-    R
-  >
-  (t1: T1, t2?: PlaceHolder, t3?: PlaceHolder): Curry2<T2, T3, R>
-  (t1: PlaceHolder, t2: T2, t3?: PlaceHolder): Curry2<T1, T3, R>
+  (t1: T1): Curry2<T2, T3, R>
+  (t1: PlaceHolder, t2: T2): Curry2<T1, T3, R>
   (t1: PlaceHolder, t2: PlaceHolder, t3: T3): Curry2<T1, T2, R>
-  (t1: T1, t2: T2, t3?: PlaceHolder): Curry1<T3, R>
+  (t1: T1, t2: T2): Curry1<T3, R>
   (t1: PlaceHolder, t2: T2, t3: T3): Curry1<T1, R>
   (t1: T1, t2: PlaceHolder, t3: T3): Curry1<T2, R>
   (t1: T1, t2: T2, t3: T3): R


### PR DESCRIPTION
Fixes #57 
`flip` function takes a function for arity two or more and returns a new curried function. The returned function, when called, calls the original function with first two arguments flipped. This means that the type for first two parameters will have same type. That had been restricted in the types. 

Since, the returned function is curried, we can not directly return the function with the appropriate types yet. Hence, the returned function is an any function with signature `(this: any, ...passed: any[]) => any`. To make the types stricter, one can use the interfaces- `Curry1` or `Curry2` or `Curry3`.

Also, during #52, the unnecessary types were not removed from the interfaces `Curry1`, `Curry2` and `Curry3`. This PR includes that change too