### PR TITLE
fix: remove no-prototype-builtins, prefer-const, no-inferrable-types

### DIFF
--- a/addIndex.ts
+++ b/addIndex.ts
@@ -16,7 +16,7 @@ function _addIndex(fn: Func) {
     const args = [...arguments];
 
     args[0] = function () {
-      let result = origFn.apply(
+      const result = origFn.apply(
         this,
         concat([...arguments], [index, list]),
       );

--- a/assoc.ts
+++ b/assoc.ts
@@ -37,7 +37,7 @@ type Assoc =
 function _assoc(prop: string | number, val: unknown, obj: ObjRec) {
   const result: ObjRec = {};
 
-  for (let p in obj) result[p] = obj[p];
+  for (const p in obj) result[p] = obj[p];
 
   result[prop] = val;
   return result;

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -14,11 +14,8 @@
       "tags": ["recommended"],
       "exclude": [
         "no-explicit-any",
-        "prefer-const",
         "ban-types",
-        "no-inferrable-types",
         "no-fallthrough",
-        "no-prototype-builtins",
         "ban-ts-comment"
       ]
     }

--- a/dissoc.ts
+++ b/dissoc.ts
@@ -16,7 +16,7 @@ type Dissoc =
 function _dissoc(prop: string | number, obj: ObjRec) {
   const result: ObjRec = {};
 
-  for (let p in obj) result[p] = obj[p];
+  for (const p in obj) result[p] = obj[p];
 
   delete result[prop];
   return result;

--- a/median.ts
+++ b/median.ts
@@ -15,7 +15,7 @@ function _median(list: number[]) {
 
   if (len === 0) return NaN;
 
-  let listSorted: number[] = sort(
+  const listSorted: number[] = sort(
     comparator<number>((a, b) => a < b),
     list,
   );

--- a/reduce.ts
+++ b/reduce.ts
@@ -85,7 +85,7 @@ function _reduce<T, R, P>(
   acc: R,
   functor: FunctorWithArLk<T>,
 ): R {
-  let trans = getTransformer(func);
+  const trans = getTransformer(func);
   if (isArrayLike(functor)) return _arrayReduce(trans, acc, functor);
   if (isIterable(functor)) {
     return _iterableReduce(trans, acc, getIterator<T>(functor));

--- a/specs/_async.ts
+++ b/specs/_async.ts
@@ -1,5 +1,6 @@
 export function it(fun: Function) {
   return async function () {
+    // deno-lint-ignore ban-types
     let done: Function = () => void 0;
     const p = new Promise<void>((resolve) => {
       const d = () => resolve();

--- a/specs/_async.ts
+++ b/specs/_async.ts
@@ -1,8 +1,8 @@
 export function it(fun: Function) {
   return async function () {
     let done: Function = () => void 0;
-    const p = new Promise((resolve) => {
-      let d = () => resolve();
+    const p = new Promise<void>((resolve) => {
+      const d = () => resolve();
       done = d;
     });
     await fun(done);

--- a/specs/addIndex.test.ts
+++ b/specs/addIndex.test.ts
@@ -9,11 +9,11 @@ describe('addIndex', () => {
 
   const indexedReduce = addIndex(reduce);
 
-  let sumArr = (tot: number, num: number, idx: number) => {
+  const sumArr = (tot: number, num: number, idx: number) => {
     return tot + num + idx;
   };
 
-  let squareEnds = (x: any, idx: number, list: ArrayLike<any>) => {
+  const squareEnds = (x: any, idx: number, list: ArrayLike<any>) => {
     return idx === 0 || idx === list.length - 1 ? x * x : x;
   };
 
@@ -34,7 +34,7 @@ describe('addIndex', () => {
   });
 
   it('should pass params in order: iteratorFunc, index, list', () => {
-    let makeSquareEnds = indexedMap(squareEnds);
+    const makeSquareEnds = indexedMap(squareEnds);
     eq(makeSquareEnds(list), [
       16,
       'f',

--- a/specs/allPass.test.ts
+++ b/specs/allPass.test.ts
@@ -3,13 +3,14 @@ import { allPass } from '../mod.ts';
 import { eq } from './utils/utils.ts';
 
 describe('allPass', () => {
-  let odd = (n: number) => (n & 1) == 1;
-  let lt20 = (n: number) => n < 20;
-  let gt5 = (n: number) => n > 5;
-  let plusEq = (w: number, x: number, y: number, z: number) => w + x === y + z;
+  const odd = (n: number) => (n & 1) == 1;
+  const lt20 = (n: number) => n < 20;
+  const gt5 = (n: number) => n > 5;
+  const plusEq = (w: number, x: number, y: number, z: number) =>
+    w + x === y + z;
 
   it('should report whether all predicates are satisfied by a given value', () => {
-    let ok = allPass([odd, lt20, gt5]);
+    const ok = allPass([odd, lt20, gt5]);
     eq(ok(7), true);
     eq(ok(9), true);
     eq(ok(10), false);

--- a/specs/anyPass.test.ts
+++ b/specs/anyPass.test.ts
@@ -3,13 +3,14 @@ import { anyPass } from '../mod.ts';
 import { eq } from './utils/utils.ts';
 
 describe('anyPass', () => {
-  let odd = (n: number) => (n & 1) == 1;
-  let gt20 = (n: number) => n > 20;
-  let lt5 = (n: number) => n < 5;
-  let plusEq = (w: number, x: number, y: number, z: number) => w + x === y + z;
+  const odd = (n: number) => (n & 1) == 1;
+  const gt20 = (n: number) => n > 20;
+  const lt5 = (n: number) => n < 5;
+  const plusEq = (w: number, x: number, y: number, z: number) =>
+    w + x === y + z;
 
   it('should report whether any predicates are satisfied by a given value', () => {
-    let ok = anyPass([odd, gt20, lt5]);
+    const ok = anyPass([odd, gt20, lt5]);
     eq(ok(7), true);
     eq(ok(9), true);
     eq(ok(10), false);

--- a/specs/chain.test.ts
+++ b/specs/chain.test.ts
@@ -8,7 +8,7 @@ describe('chain', () => {
   const times2 = (x: number) => [x * 2];
 
   const list = [10, undefined, 35, Infinity];
-  let c = chain(_, list);
+  const c = chain(_, list);
 
   it('maps a function over a nested list and returns the result', function () {
     // fae-no-check

--- a/specs/defaultTo.test.ts
+++ b/specs/defaultTo.test.ts
@@ -3,7 +3,7 @@ import { _, defaultTo } from '../mod.ts';
 import { eq } from './utils/utils.ts';
 
 describe('defaultTo', () => {
-  let defaultTo125 = defaultTo(125);
+  const defaultTo125 = defaultTo(125);
 
   it('should return the default value if input is null, undefined or NaN', () => {
     eq(defaultTo125(null), 125);

--- a/specs/either.test.ts
+++ b/specs/either.test.ts
@@ -4,9 +4,9 @@ import { eq } from './utils/utils.ts';
 
 describe('either', () => {
   it('should combine two boolean-returning functions into one', () => {
-    let even = (x: number) => (x & 1) === 0;
-    let gt10 = (x: number) => x > 10;
-    let f = either(even, gt10);
+    const even = (x: number) => (x & 1) === 0;
+    const gt10 = (x: number) => x > 10;
+    const f = either(even, gt10);
     eq(f(8), true);
     eq(f(13), true);
     eq(f(7), false);
@@ -16,9 +16,9 @@ describe('either', () => {
   });
 
   it('should accept functions that take multiple parameters', () => {
-    let between = (a: number, b: number, c: number) => a < b && b < c;
-    let total20 = (a: number, b: number, c: number) => a + b + c === 20;
-    let f = either(between, total20);
+    const between = (a: number, b: number, c: number) => a < b && b < c;
+    const total20 = (a: number, b: number, c: number) => a + b + c === 20;
+    const f = either(between, total20);
     eq(f(4, 5, 8), true);
     eq(f(12, 2, 6), true);
     eq(f(7, 5, 1), false);
@@ -28,13 +28,13 @@ describe('either', () => {
   });
 
   it('should test curried versions too', () => {
-    let even = (x: number) => (x & 1) === 0;
-    let gt10 = (x: number) => x > 10;
-    let f = either(_, gt10)(even);
+    const even = (x: number) => (x & 1) === 0;
+    const gt10 = (x: number) => x > 10;
+    const f = either(_, gt10)(even);
     eq(f(8), true);
     eq(f(13), true);
     eq(f(7), false);
-    let g = either(even)(gt10);
+    const g = either(even)(gt10);
     eq(g(8), true);
     eq(g(13), true);
     eq(g(7), false);

--- a/specs/findIndex.test.ts
+++ b/specs/findIndex.test.ts
@@ -3,9 +3,9 @@ import { _, findIndex } from '../mod.ts';
 import { eq } from './utils/utils.ts';
 
 describe('findIndex', () => {
-  let obj1 = { x: 10 };
-  let a = [2, 4, obj1, 3, 12, 25, obj1, 'Foo', undefined, 21];
-  let b = [2, 4, 3, 12, 25, 21];
+  const obj1 = { x: 10 };
+  const a = [2, 4, obj1, 3, 12, 25, obj1, 'Foo', undefined, 21];
+  const b = [2, 4, 3, 12, 25, 21];
 
   // TODO: (ch-shubham) Add Testing Support for Predicates
 

--- a/specs/identity.test.ts
+++ b/specs/identity.test.ts
@@ -12,8 +12,8 @@ describe('identity', () => {
   });
 
   it('should returns its return value of function being passes', function () {
-    let f = (x: number) => ++x;
-    let g = (y: string) => y + 'bar';
+    const f = (x: number) => ++x;
+    const g = (y: string) => y + 'bar';
     eq(identity(f(1)), 2);
     eq(identity(g('foo')), 'foobar');
   });

--- a/specs/lensProp.test.ts
+++ b/specs/lensProp.test.ts
@@ -29,7 +29,7 @@ describe('lensProp: view', () => {
 
 describe('lensProp: set', () => {
   it('should set the value of the object property specified', () => {
-    let result = set<TestObj, TestObjEl>(lensProp('a'), 0, testObj);
+    const result = set<TestObj, TestObjEl>(lensProp('a'), 0, testObj);
     eq(result, { a: 0, b: 2, c: 3 });
     // new object
     eq(result == testObj, false);

--- a/specs/max.test.ts
+++ b/specs/max.test.ts
@@ -33,8 +33,8 @@ describe('max', () => {
   });
 
   it('should test curried versions too', () => {
-    let d1: Date = new Date('2001-01-01');
-    let d2: Date = new Date('2002-02-02');
+    const d1: Date = new Date('2001-01-01');
+    const d2: Date = new Date('2002-02-02');
 
     eq(max(d1)(d2), d2);
     // @ts-expect-error: because max(a, b) === max(b, a)

--- a/specs/min.test.ts
+++ b/specs/min.test.ts
@@ -33,8 +33,8 @@ describe('min', () => {
   });
 
   it('should work for any orderable type', () => {
-    let d1: Date = new Date('01-01-2001');
-    let d2: Date = new Date('01-01-2002');
+    const d1: Date = new Date('01-01-2001');
+    const d2: Date = new Date('01-01-2002');
 
     eq(min(d1)(d2), d1);
     // @ts-expect-error: because min(a, b) === min(b, a)

--- a/specs/or.test.ts
+++ b/specs/or.test.ts
@@ -4,7 +4,7 @@ import { eq } from './utils/utils.ts';
 
 describe('or', () => {
   it('should compare two values', () => {
-    let a = { a: 2 };
+    const a = { a: 2 };
     eq(or(true, true), true);
     eq(or(true, false), true);
     eq(or(false, true), true);

--- a/specs/pathOr.test.ts
+++ b/specs/pathOr.test.ts
@@ -4,7 +4,7 @@ import { _, pathOr } from '../mod.ts';
 import { eq } from './utils/utils.ts';
 
 describe('pathOr', () => {
-  let deepObject = {
+  const deepObject = {
     a: { b: { c: 'c' } },
     falseVal: false,
     nullVal: null,
@@ -13,7 +13,7 @@ describe('pathOr', () => {
   };
 
   it('should take a path and an object and returns the value at the path or the default value', () => {
-    let obj = {
+    const obj = {
       a: {
         b: {
           c: 100,

--- a/specs/propEq.test.ts
+++ b/specs/propEq.test.ts
@@ -3,13 +3,13 @@ import { _, propEq } from '../mod.ts';
 import { eq } from './utils/utils.ts';
 
 describe('propEq', () => {
-  let obj1 = {
+  const obj1 = {
     name: 'Shubham',
     age: 22,
     hair: 'blue',
     isMarried: true,
   };
-  let obj2 = {
+  const obj2 = {
     name: 'Shivam',
     age: 21,
     hair: 'black',

--- a/specs/propOr.test.ts
+++ b/specs/propOr.test.ts
@@ -4,10 +4,10 @@ import { eq } from './utils/utils.ts';
 
 describe('propOr', () => {
   type O = Record<string, string | null | undefined>;
-  let shubham = { name: 'shubham', age: 23 };
-  let shivam = { age: 99 };
+  const shubham = { name: 'shubham', age: 23 };
+  const shivam = { age: 99 };
 
-  let num = propOr('Unknown', 'name');
+  const num = propOr('Unknown', 'name');
 
   it('should return a function that fetches the appropriate property', () => {
     eq(typeof num, 'function');

--- a/specs/propSatisfies.test.ts
+++ b/specs/propSatisfies.test.ts
@@ -3,7 +3,7 @@ import { _, propSatisfies } from '../mod.ts';
 import { eq } from './utils/utils.ts';
 
 describe('propSatisfies', () => {
-  let isPositive = (n: number) => n > 0;
+  const isPositive = (n: number) => n > 0;
   const obj = { x: 1, y: 0 };
 
   it('should return true if the specified object property satisfies the given predicate', () => {

--- a/specs/whereAll.test.ts
+++ b/specs/whereAll.test.ts
@@ -20,13 +20,13 @@ describe('whereAll', () => {
   };
 
   it('should be properly declared.', function () {
-    let spec = { x: equals('foo'), y: equals(7) };
-    let spec2 = { x: equals(undefined) };
-    let test1 = { x: 12, y: 200 };
-    let test2 = { x: 'foo', y: 7 };
-    let test4 = { x: null };
-    let test5 = { x: undefined };
-    let test6 = { x: 1 };
+    const spec = { x: equals('foo'), y: equals(7) };
+    const spec2 = { x: equals(undefined) };
+    const test1 = { x: 12, y: 200 };
+    const test2 = { x: 'foo', y: 7 };
+    const test4 = { x: null };
+    const test5 = { x: undefined };
+    const test6 = { x: 1 };
 
     eq(whereAll(spec, test1), false);
     eq(whereAll(spec, test2), true);
@@ -52,12 +52,12 @@ describe('whereAll', () => {
   });
 
   it('should not need the spec and the test object to have the same interface (the test object will have a superset of the specs properties)', function () {
-    let spec = { x: equals(20) };
-    let spec2 = { x: equals(20), z: equals('foo') };
-    let test1 = { x: 125, y: 100, z: 100 };
-    let test2 = { p: 1, x: 20, y: 100, z: 100 };
-    let test3 = { x: 20, y: 'foo' };
-    let test4 = { x: 125 };
+    const spec = { x: equals(20) };
+    const spec2 = { x: equals(20), z: equals('foo') };
+    const test1 = { x: 125, y: 100, z: 100 };
+    const test2 = { p: 1, x: 20, y: 100, z: 100 };
+    const test3 = { x: 20, y: 'foo' };
+    const test4 = { x: 125 };
 
     eq(whereAll(spec, test1), false);
     eq(whereAll(spec, test2), true);
@@ -92,9 +92,9 @@ describe('whereAll', () => {
   });
 
   it('should test curried versions too', () => {
-    let spec = { x: equals(20), z: equals('foo') };
-    let test1 = { x: 125, y: 100, z: 100 };
-    let test2 = { x: 20, z: 'foo' };
+    const spec = { x: equals(20), z: equals('foo') };
+    const test1 = { x: 125, y: 100, z: 100 };
+    const test2 = { x: 20, z: 'foo' };
 
     eq(whereAll(spec)(test1), false);
     eq(whereAll(_, test2)(spec), true);

--- a/specs/whereAny.test.ts
+++ b/specs/whereAny.test.ts
@@ -70,9 +70,9 @@ describe('whereAny', () => {
   });
 
   it('should test curried versions too', () => {
-    let spec = { x: equals(20), z: equals('foo') };
-    let test1 = { x: 200, y: 100, z: 100 };
-    let test2 = { x: 10, z: 'foo' };
+    const spec = { x: equals(20), z: equals('foo') };
+    const test1 = { x: 200, y: 100, z: 100 };
+    const test2 = { x: 10, z: 'foo' };
 
     eq(whereAny(spec)(test1), false);
     eq(whereAny(_, test2)(spec), true);

--- a/specs/whereEq.test.ts
+++ b/specs/whereEq.test.ts
@@ -19,11 +19,11 @@ describe('whereEq', () => {
   };
 
   it('should return true if the test object satisfies the spec otherwise false', () => {
-    let spec = { x: 1, y: 2 };
-    let test1 = { x: 0, y: 200 };
-    let test2 = { x: 0, y: 10 };
-    let test3 = { x: 1, y: 101 };
-    let test4 = { x: 1, y: 2 };
+    const spec = { x: 1, y: 2 };
+    const test1 = { x: 0, y: 200 };
+    const test2 = { x: 0, y: 10 };
+    const test3 = { x: 1, y: 101 };
+    const test4 = { x: 1, y: 2 };
 
     eq(whereEq(spec, test1), false);
     eq(whereEq(spec, test2), false);
@@ -35,12 +35,12 @@ describe('whereEq', () => {
   });
 
   it('should work if interfaces are different', () => {
-    let spec = { x: 100 };
-    let spec2 = { w: 1, x: 100, y: 200 };
-    let test1 = { x: 20, y: 100, z: 100 };
-    let test2 = { w: 1, x: 100, y: 100, z: 100 };
-    let test3 = {};
-    let test4 = { w: 1, x: 100 };
+    const spec = { x: 100 };
+    const spec2 = { w: 1, x: 100, y: 200 };
+    const test1 = { x: 20, y: 100, z: 100 };
+    const test2 = { w: 1, x: 100, y: 100, z: 100 };
+    const test3 = {};
+    const test4 = { w: 1, x: 100 };
 
     eq(whereEq(spec, test1), false);
     eq(whereEq(spec, test2), true);
@@ -49,9 +49,9 @@ describe('whereEq', () => {
   });
 
   it('should match specs that have undefined properties', () => {
-    let spec = { x: undefined };
-    let test1 = {};
-    let test2 = { x: 1 };
+    const spec = { x: undefined };
+    const test1 = {};
+    const test2 = { x: 1 };
 
     eq(whereEq(spec, test1), true);
     eq(whereEq(spec, test2), false);
@@ -62,9 +62,9 @@ describe('whereEq', () => {
   });
 
   it('should test curried versions too', () => {
-    let spec = { x: 20, z: 'foo' };
-    let test1 = { x: 125, y: 100, z: 100 };
-    let test2 = { x: 20, z: 'foo' };
+    const spec = { x: 20, z: 'foo' };
+    const test1 = { x: 125, y: 100, z: 100 };
+    const test2 = { x: 20, z: 'foo' };
 
     eq(whereEq(spec)(test1), false);
     eq(whereEq(_, test2)(spec), true);

--- a/utils/Transformers/aperture.ts
+++ b/utils/Transformers/aperture.ts
@@ -4,8 +4,8 @@ export default class ApertureTransformer<
   T = any,
 > extends Transformer {
   private n: number;
-  // deno-lint-ignore no-inferrable-types
-  private i: number = 0;
+
+  private i = 0;
   private buffer: T[];
   private full = false;
   constructor(n: number, transformer: Transformer) {

--- a/utils/Transformers/aperture.ts
+++ b/utils/Transformers/aperture.ts
@@ -4,6 +4,7 @@ export default class ApertureTransformer<
   T = any,
 > extends Transformer {
   private n: number;
+  // deno-lint-ignore no-inferrable-types
   private i: number = 0;
   private buffer: T[];
   private full = false;

--- a/utils/curry_n.ts
+++ b/utils/curry_n.ts
@@ -25,7 +25,7 @@ function _curryN<F extends (...args: any[]) => any>(
       ? original.apply(this, allArgs)
       : _curryN(totalArgs, allArgs, original);
   }
-  let rem = received.filter((r) => r === UNDEFINED).length;
+  const rem = received.filter((r) => r === UNDEFINED).length;
   setFunctionLength(f, rem);
   return f;
 }

--- a/utils/is.ts
+++ b/utils/is.ts
@@ -34,12 +34,11 @@ export function isArrayLike<T = any>(x: any): x is ArrayLike<T> {
   if (isArray(x)) return true;
   if (x.length) {
     if (x.length === 0) return true;
+    console;
     if (
       x.length > 0 &&
-      // deno-lint-ignore no-prototype-builtins
-      x.hasOwnProperty(0) &&
-      // deno-lint-ignore no-prototype-builtins
-      x.hasOwnProperty(x.length - 1)
+      Object.prototype.hasOwnProperty.call(x, 0) &&
+      Object.prototype.hasOwnProperty.call(x, x.length - 1)
     ) {
       return true;
     }

--- a/utils/is.ts
+++ b/utils/is.ts
@@ -36,7 +36,9 @@ export function isArrayLike<T = any>(x: any): x is ArrayLike<T> {
     if (x.length === 0) return true;
     if (
       x.length > 0 &&
+      // deno-lint-ignore no-prototype-builtins
       x.hasOwnProperty(0) &&
+      // deno-lint-ignore no-prototype-builtins
       x.hasOwnProperty(x.length - 1)
     ) {
       return true;


### PR DESCRIPTION
fixes #74 removed `no-prototype-builtins`, `prefer-const` and `no-inferrable-types` lint rule from the lint-exclude option