### PR TITLE
type(dissoc): enhance types to omit keys in types too

### DIFF
--- a/dissoc.ts
+++ b/dissoc.ts
@@ -4,14 +4,14 @@ import type { ObjRec, PH } from './utils/types.ts';
 import curryN from './utils/curry_n.ts';
 
 // @types
-type Dissoc_2 = (obj: ObjRec) => ObjRec;
+type Dissoc_2<P extends string | number> = <T>(obj: T) => Omit<T, P>;
 
-type Dissoc_1 = (prop: string | number) => ObjRec;
+type Dissoc_1<T> = <P extends keyof T>(prop: P) => Omit<T, P>;
 
 type Dissoc =
-  & ((prop: string | number) => Dissoc_2)
-  & ((prop: PH, obj: ObjRec) => Dissoc_1)
-  & ((prop: string | number, obj: ObjRec) => ObjRec);
+  & (<P extends string | number>(prop: P) => Dissoc_2<P>)
+  & (<T>(prop: PH, obj: T) => Dissoc_1<T>)
+  & (<T, P extends keyof T>(prop: P, obj: T) => Omit<T, P>);
 
 function _dissoc(prop: string | number, obj: ObjRec) {
   const result: ObjRec = {};

--- a/specs/dissoc.test.ts
+++ b/specs/dissoc.test.ts
@@ -1,45 +1,84 @@
 import { describe, it } from './_describe.ts';
 import { _, dissoc } from '../mod.ts';
-import { eq } from './utils/utils.ts';
+import { eq, exactType } from './utils/utils.ts';
 
 describe('dissoc', () => {
+  const given = { a: 1, b: 2, c: 3 };
+  const exptectedOmitB = { a: 1, c: 3 };
   it('should copy an object omitting the specified property', () => {
-    eq(dissoc('b', { a: 1, b: 2, c: 3 }), { a: 1, c: 3 });
-    eq(dissoc('d', { a: 1, b: 2, c: 3 }), { a: 1, b: 2, c: 3 });
+    eq(dissoc('b', given), exptectedOmitB);
+
+    // @ts-expect-error: property d does not exist
+    eq(dissoc('d', given), given);
   });
 
   it('should include prototype properties', () => {
-    function Rectangle(this: unknown, width: number, height: number) {
-      // @ts-ignore: https://github.com/Jozty/Fae/issues/81
-      this.width = width;
-      // @ts-ignore: https://github.com/Jozty/Fae/issues/81
-      this.height = height;
+    interface RectInterface {
+      width: number;
+      height: number;
+      area: () => number;
     }
 
-    const area = (Rectangle.prototype.area = () => {
-      // @ts-ignore: https://github.com/Jozty/Fae/issues/81
+    const Rectangle = function (
+      this: RectInterface,
+      width: number,
+      height: number,
+    ) {
+      this.width = width;
+      this.height = height;
+    } as unknown as { new (width: number, height: number): RectInterface };
+
+    const area = (Rectangle.prototype.area = function (this: RectInterface) {
       return this.width * this.height;
     });
 
-    // @ts-ignore: https://github.com/Jozty/Fae/issues/81
-    const rect = new Rectangle(7, 6);
+    const rect: RectInterface = new Rectangle(7, 6);
 
-    // @ts-ignore: https://github.com/Jozty/Fae/issues/81
     eq(dissoc('area', rect), { width: 7, height: 6 });
 
-    // @ts-ignore: https://github.com/Jozty/Fae/issues/81
     eq(dissoc('width', rect), { height: 6, area: area });
 
-    // @ts-ignore: https://github.com/Jozty/Fae/issues/81
+    // @ts-expect-error: 'depth' doesn't exist of type R
     eq(dissoc('depth', rect), { width: 7, height: 6, area: area });
+  });
+
+  it('should inherit lower property in prototype chain if deleted', () => {
+    const number0 = 4;
+
+    eq(number0.toString(), '4');
+    eq(number0.toString, Number.prototype.toString);
+
+    const number1 = dissoc('toString', number0);
+
+    eq(number1.toString(), '[object Object]');
+    eq(number1.toString, Object.prototype.toString);
+  });
+
+  it('should omit key types of the dissoced prop', () => {
+    eq(dissoc('b', given), exptectedOmitB);
+
+    exactType(dissoc('b', given), exptectedOmitB);
+    // @ts-expect-error: b is omitted
+    exactType(dissoc('b', given), { a: 1, c: 3, b: 2 });
+
+    // @ts-expect-error: property d does not exist
+    exactType(dissoc('d', given), exptectedOmitB);
+
+    // @ts-expect-error: b is omitted
+    exactType(dissoc('b')(given), { a: 1, c: 3, b: 2 });
+
+    // @ts-expect-error: b is omitted
+    exactType(dissoc(_, given)('b'), { a: 1, c: 3, b: 2 });
   });
 
   it('should coerce non-string types', () => {
     eq(dissoc(42, { a: 1, b: 2, 42: 3 }), { a: 1, b: 2 });
     // @ts-ignore
     eq(dissoc(null, { a: 1, b: 2, null: 3 }), { a: 1, b: 2 });
-    // @ts-ignore
+
+    // @ts-expect-error: undefined is not a valid prop
     eq(dissoc(undefined, { a: 1, b: 2, undefined: 3 }), {
+      // @ts-ignore: undefined is not a valid prop
       a: 1,
       b: 2,
     });
@@ -47,11 +86,10 @@ describe('dissoc', () => {
 
   it('should work on curried versions too', () => {
     const a = 'b';
-    const b = { a: 1, b: 2, c: 3 };
-    const expected = { a: 1, c: 3 };
+    const b = given;
 
-    eq(dissoc(a, b), expected);
-    eq(dissoc(a)(b), expected);
-    eq(dissoc(_, b)(a), expected);
+    eq(dissoc(a, b), exptectedOmitB);
+    eq(dissoc(a)(b), exptectedOmitB);
+    eq(dissoc(_, b)(a), exptectedOmitB);
   });
 });

--- a/specs/utils/utils.ts
+++ b/specs/utils/utils.ts
@@ -1,5 +1,8 @@
 import { AssertionError, assertStrictEquals, expect } from '../_describe.ts';
 
+export function exactType<T>(_actual: T, _expected: T) {
+}
+
 export function eq<T>(actual: T, expected: T) {
   expect(actual).toEqual(expected);
 }


### PR DESCRIPTION
Fixes #81 

Now, `dissoc` function omits the passed prop from the returned type.

So given a type `interface Given { a: number, b: string }`, and let's say the passed key is `"a"`, the returned type will be `{ b : string }`. This also implies that the passed keys to `dissoc` are restricted to keys that are present in the passed type.